### PR TITLE
Fixed client crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,10 @@ class quickChatReply extends Plugin {
 
 	_keyPressHandler(keyInput) {
 		if (this.filter(this.settings.get('replyNext'), keyInput)) {
-			this.message.index += 1
-			this.createReply()
+			if (this.message.index + 1 < this.fetch.message(this.message.channel).toArray().length) {
+				this.message.index += 1
+				this.createReply()
+			}
 		} else if (this.filter(this.settings.get('replyPrev'), keyInput)) {
 			this.message.index -= 1
 			if (this.message.index < 0) {


### PR DESCRIPTION
There was an issue where the message index could be increased above the amount of currently loaded messages, which caused powercord to crash when trying to create a reply, and other client mods would output errors in the console
![image](https://user-images.githubusercontent.com/42148912/146611112-580d5d9a-882b-47b5-a3a9-1fdd4d7ac548.png)
